### PR TITLE
Remove runtime dependency on Apache Logj4j.  

### DIFF
--- a/norconex-language-detector/pom.xml
+++ b/norconex-language-detector/pom.xml
@@ -53,11 +53,23 @@
       <artifactId>langdetect</artifactId>
       <version>1.3.0</version>
     </dependency>
-    <dependency>
+   	<dependency>
+ 		<groupId>org.slf4j</groupId>
+   		<artifactId>slf4j-api</artifactId>
+   		<version>1.7.12</version>
+   	</dependency>      	  
+  	<dependency>
+		<groupId>org.slf4j</groupId>
+  		<artifactId>slf4j-log4j12</artifactId>
+  		<version>1.7.12</version>
+	    <scope>test</scope>
+	</dependency>	
+	<dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
         <version>1.2.17</version>
-    </dependency>
+        <scope>test</scope>
+    </dependency>    
   </dependencies>
 
 

--- a/norconex-language-detector/src/main/java/com/norconex/language/detector/LanguageDetector.java
+++ b/norconex-language-detector/src/main/java/com/norconex/language/detector/LanguageDetector.java
@@ -24,8 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.cybozu.labs.langdetect.Detector;
 import com.cybozu.labs.langdetect.ErrorCode;
@@ -41,7 +41,7 @@ import com.cybozu.labs.langdetect.util.LangProfile;
 public class LanguageDetector {
 
     private static final Logger LOG = 
-            LogManager.getLogger(LanguageDetector.class);
+    		LoggerFactory.getLogger(LanguageDetector.class);
     
     private static final String[] DEFAULT_SHORTTEXT_LANGUAGES = new String[] {
         "ar", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es", "et", "fa",


### PR DESCRIPTION
Replaced with SLF4J.  During unit tests only bind to Log4j.
